### PR TITLE
Add Wow-64.exe patching support for Cata 4.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 bin
 obj
 *.pdb
+
+# Client binaries — do not commit or distribute patched/unpatched game executables
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ bin
 obj
 *.pdb
 
-# Client binaries — do not commit or distribute patched/unpatched game executables
+# Client binaries - do not commit or distribute patched/unpatched game executables
 *.exe

--- a/MaNGOSPatcher/Patcher/CrashReporter.cs
+++ b/MaNGOSPatcher/Patcher/CrashReporter.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace MaNGOSPatcher
+{
+    internal static class CrashReporter
+    {
+        private static int isReporting;
+
+        public static void OnThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            ReportException("Windows Forms thread exception", e.Exception);
+        }
+
+        public static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Exception exception = e.ExceptionObject as Exception;
+            if (exception == null)
+                exception = new Exception("Unhandled non-Exception object: " + Convert.ToString(e.ExceptionObject));
+
+            ReportException("AppDomain unhandled exception", exception);
+        }
+
+        public static void ReportException(string context, Exception exception)
+        {
+            if (Interlocked.Exchange(ref isReporting, 1) != 0)
+                return;
+
+            string logPath = null;
+            try
+            {
+                logPath = WriteCrashLog(context, exception);
+            }
+            catch
+            {
+                // Crash reporting must never trigger a second fatal exception.
+            }
+
+            try
+            {
+                string message = "MaNGOSPatcher encountered an unexpected error.";
+                if (!string.IsNullOrEmpty(logPath))
+                    message += "\n\nCrash report written to:\n" + logPath;
+
+                MessageBox.Show(message, "MaNGOSPatcher Error",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            catch
+            {
+            }
+        }
+
+        private static string WriteCrashLog(string context, Exception exception)
+        {
+            string directory = GetCrashLogDirectory();
+            Directory.CreateDirectory(directory);
+
+            string fileName = "crash-" + DateTime.Now.ToString("yyyyMMdd-HHmmss") + ".log";
+            string path = Path.Combine(directory, fileName);
+
+            using (StreamWriter writer = new StreamWriter(path, false, Encoding.UTF8))
+            {
+                writer.WriteLine("MaNGOSPatcher Crash Report");
+                writer.WriteLine("==========================");
+                writer.WriteLine("Time: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss zzz"));
+                writer.WriteLine("Context: " + context);
+                writer.WriteLine();
+
+                writer.WriteLine("Environment");
+                writer.WriteLine("-----------");
+                writer.WriteLine("Executable: " + Application.ExecutablePath);
+                writer.WriteLine("Current directory: " + Environment.CurrentDirectory);
+                writer.WriteLine("Command line: " + Environment.CommandLine);
+                writer.WriteLine(".NET version: " + Environment.Version);
+                writer.WriteLine("OS version: " + Environment.OSVersion);
+                writer.WriteLine("Machine name: " + Environment.MachineName);
+                writer.WriteLine("User name: " + Environment.UserName);
+                writer.WriteLine();
+
+                writer.WriteLine("Expected files in current directory");
+                writer.WriteLine("-----------------------------------");
+                WriteFileState(writer, "Wow.exe");
+                WriteFileState(writer, "Wow-64.exe");
+                WriteFileState(writer, "World of Warcraft");
+                writer.WriteLine();
+
+                writer.WriteLine("Exception");
+                writer.WriteLine("---------");
+                WriteException(writer, exception, 0);
+                writer.WriteLine();
+
+                writer.WriteLine("Loaded assemblies");
+                writer.WriteLine("-----------------");
+                Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                foreach (Assembly assembly in assemblies)
+                {
+                    writer.WriteLine(assembly.FullName);
+                    try
+                    {
+                        writer.WriteLine("  Location: " + assembly.Location);
+                    }
+                    catch
+                    {
+                        writer.WriteLine("  Location: <unavailable>");
+                    }
+                }
+            }
+
+            return path;
+        }
+
+        private static string GetCrashLogDirectory()
+        {
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrEmpty(localAppData))
+                return Path.Combine(Path.Combine(localAppData, "MaNGOSPatcher"), "CrashLogs");
+
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CrashLogs");
+        }
+
+        private static void WriteFileState(StreamWriter writer, string fileName)
+        {
+            string path = Path.Combine(Environment.CurrentDirectory, fileName);
+            if (!File.Exists(path))
+            {
+                writer.WriteLine(fileName + ": missing");
+                return;
+            }
+
+            try
+            {
+                FileInfo info = new FileInfo(path);
+                writer.WriteLine(fileName + ": present, " + info.Length + " bytes");
+            }
+            catch (Exception ex)
+            {
+                writer.WriteLine(fileName + ": present, could not read metadata: " + ex.Message);
+            }
+        }
+
+        private static void WriteException(StreamWriter writer, Exception exception, int depth)
+        {
+            if (exception == null)
+                return;
+
+            string indent = new string(' ', depth * 2);
+            writer.WriteLine(indent + "Type: " + exception.GetType().FullName);
+            writer.WriteLine(indent + "Message: " + exception.Message);
+            writer.WriteLine(indent + "Source: " + exception.Source);
+            writer.WriteLine(indent + "Stack:");
+            writer.WriteLine(exception.StackTrace);
+
+            if (exception.InnerException != null)
+            {
+                writer.WriteLine();
+                writer.WriteLine(indent + "Inner exception:");
+                WriteException(writer, exception.InnerException, depth + 1);
+            }
+        }
+    }
+}

--- a/MaNGOSPatcher/Patcher/Form1.Designer.cs
+++ b/MaNGOSPatcher/Patcher/Form1.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            System.Drawing.Icon appIcon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -90,7 +90,10 @@
             // 
             // notifyIcon1
             // 
-            this.notifyIcon1.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon1.Icon")));
+            if (appIcon != null)
+            {
+                this.notifyIcon1.Icon = appIcon;
+            }
             this.notifyIcon1.Text = "MaNGOS 4.3.4 Patcher ";
             this.notifyIcon1.Visible = true;
             // 
@@ -104,7 +107,10 @@
             this.Controls.Add(this.button1);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.groupBox1);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            if (appIcon != null)
+            {
+                this.Icon = appIcon;
+            }
             this.Name = "Form1";
             this.Text = "MaNGOSPatcher";
             this.Load += new System.EventHandler(this.Form1_Load);

--- a/MaNGOSPatcher/Patcher/Form1.cs
+++ b/MaNGOSPatcher/Patcher/Form1.cs
@@ -201,40 +201,13 @@ namespace MaNGOSPatcher
 
                 if (isPatch && t.IsUnpatched)
                 {
-                    foreach (PatchBytes p in t.Patches)
-                    {
-                        System.Buffer.BlockCopy(p.Patched, 0, t.Data, p.Offset, p.Patched.Length);
-                    }
-                    try { File.Delete(t.BackupFile); } catch { }
-                    try { File.Move(t.FileName, t.BackupFile); } catch { }
-
-                    if (WriteByteArrayToFile(t.Data, t.FileName))
-                    {
-                        report.AppendFormat("Patched {0} (backup: {1})\n", t.FileName, t.BackupFile);
-                    }
-                    else
-                    {
-                        report.AppendFormat("ERROR writing {0}\n", t.FileName);
+                    if (!PatchTargetFile(t, report))
                         overallSuccess = false;
-                    }
                 }
                 else if (!isPatch && t.IsPatched)
                 {
-                    foreach (PatchBytes p in t.Patches)
-                    {
-                        System.Buffer.BlockCopy(p.Unpatched, 0, t.Data, p.Offset, p.Unpatched.Length);
-                    }
-                    try { File.Delete(t.FileName); File.Delete(t.BackupFile); } catch { }
-
-                    if (WriteByteArrayToFile(t.Data, t.FileName))
-                    {
-                        report.AppendFormat("Restored {0}\n", t.FileName);
-                    }
-                    else
-                    {
-                        report.AppendFormat("ERROR writing {0}\n", t.FileName);
+                    if (!UnpatchTargetFile(t, report))
                         overallSuccess = false;
-                    }
                 }
             }
 
@@ -251,6 +224,150 @@ namespace MaNGOSPatcher
             }
             richTextBox1.AppendText("Done.\n\n");
             RefreshState();
+        }
+
+        private bool PatchTargetFile(PatchTarget t, StringBuilder report)
+        {
+            if (!TryDeleteExistingFile(t.BackupFile, t.FileName, "old backup", report))
+                return false;
+
+            try
+            {
+                File.Move(t.FileName, t.BackupFile);
+            }
+            catch (Exception ex)
+            {
+                report.AppendFormat("SKIPPED {0}: could not create backup {1}: {2}\n",
+                    t.FileName, t.BackupFile, ex.Message);
+                return false;
+            }
+
+            byte[] patchedData = CreatePatchedCopy(t, true);
+            if (WriteByteArrayToFile(patchedData, t.FileName))
+            {
+                report.AppendFormat("Patched {0} (backup: {1})\n", t.FileName, t.BackupFile);
+                return true;
+            }
+
+            report.AppendFormat("ERROR writing {0}; backup remains at {1}\n", t.FileName, t.BackupFile);
+            TryRestoreOriginalAfterPatchWriteFailure(t, report);
+            return false;
+        }
+
+        private bool UnpatchTargetFile(PatchTarget t, StringBuilder report)
+        {
+            string restoreFile = t.FileName + ".restore.tmp";
+            string patchedFile = t.FileName + ".patched.tmp";
+
+            if (!TryDeleteExistingFile(restoreFile, t.FileName, "temporary restore file", report))
+                return false;
+            if (!TryDeleteExistingFile(patchedFile, t.FileName, "temporary patched file", report))
+                return false;
+
+            byte[] unpatchedData = CreatePatchedCopy(t, false);
+            if (!WriteByteArrayToFile(unpatchedData, restoreFile))
+            {
+                report.AppendFormat("ERROR preparing restored copy for {0}\n", t.FileName);
+                return false;
+            }
+
+            try
+            {
+                File.Move(t.FileName, patchedFile);
+            }
+            catch (Exception ex)
+            {
+                TryDeleteFile(restoreFile, report, t.FileName, "temporary restore file");
+                report.AppendFormat("SKIPPED {0}: could not move patched file aside: {1}\n",
+                    t.FileName, ex.Message);
+                return false;
+            }
+
+            try
+            {
+                File.Move(restoreFile, t.FileName);
+            }
+            catch (Exception ex)
+            {
+                report.AppendFormat("ERROR restoring {0}: {1}\n", t.FileName, ex.Message);
+                try
+                {
+                    File.Move(patchedFile, t.FileName);
+                    report.AppendFormat("Restored patched copy of {0} after unpatch failure.\n", t.FileName);
+                }
+                catch (Exception rollbackEx)
+                {
+                    report.AppendFormat("ERROR restoring patched copy of {0}: {1}\n",
+                        t.FileName, rollbackEx.Message);
+                }
+                return false;
+            }
+
+            TryDeleteFile(patchedFile, report, t.FileName, "temporary patched file");
+            TryDeleteFile(t.BackupFile, report, t.FileName, "backup");
+            report.AppendFormat("Restored {0}\n", t.FileName);
+            return true;
+        }
+
+        private byte[] CreatePatchedCopy(PatchTarget t, bool usePatchedBytes)
+        {
+            byte[] data = (byte[])t.Data.Clone();
+            foreach (PatchBytes p in t.Patches)
+            {
+                byte[] source = usePatchedBytes ? p.Patched : p.Unpatched;
+                System.Buffer.BlockCopy(source, 0, data, p.Offset, source.Length);
+            }
+            return data;
+        }
+
+        private bool TryDeleteExistingFile(string fileName, string targetName, string description, StringBuilder report)
+        {
+            if (!File.Exists(fileName))
+                return true;
+
+            try
+            {
+                File.Delete(fileName);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                report.AppendFormat("SKIPPED {0}: could not delete {1} {2}: {3}\n",
+                    targetName, description, fileName, ex.Message);
+                return false;
+            }
+        }
+
+        private void TryDeleteFile(string fileName, StringBuilder report, string targetName, string description)
+        {
+            if (!File.Exists(fileName))
+                return;
+
+            try
+            {
+                File.Delete(fileName);
+            }
+            catch (Exception ex)
+            {
+                report.AppendFormat("WARNING {0}: could not delete {1} {2}: {3}\n",
+                    targetName, description, fileName, ex.Message);
+            }
+        }
+
+        private void TryRestoreOriginalAfterPatchWriteFailure(PatchTarget t, StringBuilder report)
+        {
+            try
+            {
+                if (File.Exists(t.FileName))
+                    File.Delete(t.FileName);
+                File.Copy(t.BackupFile, t.FileName);
+                report.AppendFormat("Restored original {0} from backup after write failure.\n", t.FileName);
+            }
+            catch (Exception ex)
+            {
+                report.AppendFormat("ERROR restoring original {0} from backup: {1}\n",
+                    t.FileName, ex.Message);
+            }
         }
 
         public byte[] ReadByteArrayFromFile(string fileName)

--- a/MaNGOSPatcher/Patcher/Form1.cs
+++ b/MaNGOSPatcher/Patcher/Form1.cs
@@ -14,15 +14,27 @@ namespace MaNGOSPatcher
 {
     public partial class Form1 : Form
     {
-        byte[] wowExe = null;
+        internal class PatchTarget
+        {
+            public string FileName;
+            public string BackupFile;
+            public byte[] Data;
+            public List<PatchBytes> Patches;
+            public bool Ready;
+            public bool IsUnpatched;
+            public bool IsPatched;
+            public string MismatchReport;
+        }
+
         Dictionary<int, List<PatchBytes>> Patches = new Dictionary<int, List<PatchBytes>>();
-        List<PatchBytes> patches = null;
+        List<PatchTarget> Targets = new List<PatchTarget>();
+
         const string FileWin = "Wow.exe";
         const string BackupWin = "Wow_backup.exe";
+        const string FileWin64 = "Wow-64.exe";
+        const string BackupWin64 = "Wow-64_backup.exe";
         const string FileMac = "World of Warcraft";
         const string BackupMac = "World of Warcraft backup";
-        string FileName;
-        string BackupFile;
 
         public Form1()
         {
@@ -39,116 +51,206 @@ namespace MaNGOSPatcher
                     Patches.Add(pInfo.ExeLength, pInfo.Patches);
                 }
             }
+
+            RefreshState();
+        }
+
+        private void RefreshState()
+        {
+            Targets.Clear();
+
+            TryLoadBinary(FileWin64, BackupWin64, "Windows 'Wow-64.exe'");
+            TryLoadBinary(FileWin, BackupWin, "Windows 'Wow.exe'");
+            TryLoadBinary(FileMac, BackupMac, "Mac 'World of Warcraft'");
+
+            if (Targets.Count == 0)
+            {
+                richTextBox1.AppendText("Could not load Win 'Wow-64.exe', 'Wow.exe' or Mac 'World of Warcraft' into memory. Make sure this program is in your WoW directory and that WoW is closed.\n");
+                label2.Text = "Error";
+                label2.ForeColor = Color.Red;
+                button1.Enabled = false;
+                return;
+            }
+
+            bool anyReady = false;
+            bool anyUnpatched = false;
+            bool allPatched = true;
+            StringBuilder summary = new StringBuilder();
+
+            foreach (PatchTarget t in Targets)
+            {
+                ValidateTarget(t);
+                if (t.Ready)
+                {
+                    anyReady = true;
+                    if (t.IsUnpatched) anyUnpatched = true;
+                    if (!t.IsPatched) allPatched = false;
+                    summary.AppendFormat("  {0}: {1} patch sites {2}\n", t.FileName, t.Patches.Count,
+                        t.IsPatched ? "already patched" : (t.IsUnpatched ? "ready to patch" : "mixed state"));
+                }
+                else
+                {
+                    summary.AppendFormat("  {0}: validation FAILED\n", t.FileName);
+                    if (!string.IsNullOrEmpty(t.MismatchReport))
+                        summary.Append(t.MismatchReport);
+                }
+            }
+
+            richTextBox1.AppendText(summary.ToString());
+
+            if (!anyReady)
+            {
+                richTextBox1.AppendText("No supported binaries passed validation. Patching disabled.\n");
+                label2.Text = "Mismatch";
+                label2.ForeColor = Color.Red;
+                button1.Enabled = false;
+                return;
+            }
+
+            label2.Text = "Ready!";
+            label2.ForeColor = Color.Orange;
+            button1.Enabled = true;
+
+            if (anyUnpatched)
+            {
+                button1.Text = "Patch";
+                richTextBox1.AppendText("Ready to patch all verified binaries.\n");
+            }
+            else if (allPatched)
+            {
+                button1.Text = "Unpatch";
+                richTextBox1.AppendText("All verified binaries already patched. Click \"Unpatch\" to restore.\n");
+            }
+            else
+            {
+                button1.Text = "Patch";
+                richTextBox1.AppendText("Some binaries are in a mixed state. Click \"Patch\" to synchronize.\n");
+            }
+        }
+
+        private void TryLoadBinary(string fileName, string backupFile, string displayName)
+        {
             try
             {
-                richTextBox1.AppendText("Loading Wow.exe into memory...\n");
-                wowExe = ReadByteArrayFromFile(FileWin);
-                if(!Patches.ContainsKey(wowExe.Length))
+                byte[] data = ReadByteArrayFromFile(fileName);
+                if (!Patches.ContainsKey(data.Length))
                 {
-                    richTextBox1.AppendText("This Wow.exe version is not supported\n");
-                    throw new Exception("Version not supported");
+                    richTextBox1.AppendText("This " + displayName + " version is not supported\n");
+                    return;
                 }
-                patches = Patches[wowExe.Length];
-                richTextBox1.AppendText("Success Windows 'wow.exe' loaded!\n");
-                BackupFile = BackupWin;
-                FileName = FileWin;
+                richTextBox1.AppendText("Loaded " + displayName + " (" + data.Length + " bytes)\n");
+                Targets.Add(new PatchTarget
+                {
+                    FileName = fileName,
+                    BackupFile = backupFile,
+                    Data = data,
+                    Patches = Patches[data.Length],
+                    Ready = false,
+                    IsUnpatched = false,
+                    IsPatched = false,
+                    MismatchReport = ""
+                });
             }
             catch
             {
-                try
-                {
-                    richTextBox1.AppendText("Loading Mac 'World of Warcraft' binary into memory...\n");
-                    wowExe = ReadByteArrayFromFile(FileMac);
-                    richTextBox1.AppendText("Success Mac 'World of Warcraft' loaded!\n");
-                    BackupFile = BackupMac;
-                    FileName = FileMac;
-                    if (!Patches.ContainsKey(wowExe.Length))
-                    {
-                        richTextBox1.AppendText("This Mac version is not supported\n");
-                        throw new Exception("Version not supported");
-                    }
-                    patches = patches = Patches[wowExe.Length];
-                }
-                catch
-                {
-                    richTextBox1.AppendText("Could not load Win 'Wow.exe' or Mac 'World of Warcraft' into memory. Make sure this program is in your WoW directory and that WoW is closed.\n");
-                    label2.Text = "Error";
-                    label2.ForeColor = Color.Red;
-                    wowExe = null;
-                }
-                //filenotfound or fileinuse
+                richTextBox1.AppendText(displayName + " not found.\n");
             }
+        }
 
-            if (wowExe != null)
+        private void ValidateTarget(PatchTarget t)
+        {
+            bool allUnpatched = true;
+            bool allPatched = true;
+            StringBuilder mismatchReport = new StringBuilder();
+
+            foreach (PatchBytes p in t.Patches)
             {
-                byte[] testPatched = new byte[patches[0].Unpatched.Length];
-                System.Buffer.BlockCopy(wowExe, patches[0].Offset, testPatched, 0, patches[0].Unpatched.Length);
+                byte[] current = new byte[p.Unpatched.Length];
+                System.Buffer.BlockCopy(t.Data, p.Offset, current, 0, p.Unpatched.Length);
 
-                if (testPatched.SequenceEqual(patches[0].Unpatched))
+                if (!current.SequenceEqual(p.Unpatched))
+                    allUnpatched = false;
+                if (!current.SequenceEqual(p.Patched))
+                    allPatched = false;
+
+                if (!current.SequenceEqual(p.Unpatched) && !current.SequenceEqual(p.Patched))
                 {
-                    richTextBox1.AppendText("Ready to patch " + FileName + ".\n");
-                    label2.Text = "Ready!";
-                    label2.ForeColor = Color.Orange;
-                    button1.Text = "Patch";
-                    button1.Enabled = true;
-                }
-                if (testPatched.SequenceEqual(patches[0].Patched))
-                {
-                    richTextBox1.AppendText("To restore " + FileName + " click \"Unpatch\".\n");
-                    label2.Text = "Ready!";
-                    label2.ForeColor = Color.Orange;
-                    button1.Text = "Unpatch";
-                    button1.Enabled = true;
+                    string actual = BitConverter.ToString(current).Replace("-", " ");
+                    string expectedUnpatched = BitConverter.ToString(p.Unpatched).Replace("-", " ");
+                    string expectedPatched = BitConverter.ToString(p.Patched).Replace("-", " ");
+                    mismatchReport.AppendFormat("    Offset 0x{0:X}: expected unpatched [{1}] or patched [{2}], found [{3}]\n",
+                        p.Offset, expectedUnpatched, expectedPatched, actual);
                 }
             }
+
+            t.IsUnpatched = allUnpatched;
+            t.IsPatched = allPatched;
+            t.MismatchReport = mismatchReport.ToString();
+            t.Ready = allUnpatched || allPatched;
         }
 
         private void button1_Click(object sender, EventArgs e)
         {
-            if (((Button)sender).Text == "Patch")
-            {
-                foreach (PatchBytes p in patches)
-                {
-                    System.Buffer.BlockCopy(p.Patched, 0, wowExe, p.Offset, p.Patched.Length);
-                }
-                try { File.Delete(BackupFile); } catch { }
-                try { File.Move(FileName, BackupFile); } catch {}
+            bool isPatch = ((Button)sender).Text == "Patch";
+            bool overallSuccess = true;
+            StringBuilder report = new StringBuilder();
 
-                if (WriteByteArrayToFile(wowExe, FileName) == true)
+            foreach (PatchTarget t in Targets)
+            {
+                if (!t.Ready) continue;
+
+                if (isPatch && t.IsUnpatched)
                 {
-                    richTextBox1.AppendText("Successfully patched " + FileName + " and created a backup " + BackupFile +"!\n");
-                    label2.Text = "Success!";
-                    label2.ForeColor = Color.Green;
+                    foreach (PatchBytes p in t.Patches)
+                    {
+                        System.Buffer.BlockCopy(p.Patched, 0, t.Data, p.Offset, p.Patched.Length);
+                    }
+                    try { File.Delete(t.BackupFile); } catch { }
+                    try { File.Move(t.FileName, t.BackupFile); } catch { }
+
+                    if (WriteByteArrayToFile(t.Data, t.FileName))
+                    {
+                        report.AppendFormat("Patched {0} (backup: {1})\n", t.FileName, t.BackupFile);
+                    }
+                    else
+                    {
+                        report.AppendFormat("ERROR writing {0}\n", t.FileName);
+                        overallSuccess = false;
+                    }
                 }
-                else
+                else if (!isPatch && t.IsPatched)
                 {
-                    label2.Text = "Error!";
-                    label2.ForeColor = Color.Red;
+                    foreach (PatchBytes p in t.Patches)
+                    {
+                        System.Buffer.BlockCopy(p.Unpatched, 0, t.Data, p.Offset, p.Unpatched.Length);
+                    }
+                    try { File.Delete(t.FileName); File.Delete(t.BackupFile); } catch { }
+
+                    if (WriteByteArrayToFile(t.Data, t.FileName))
+                    {
+                        report.AppendFormat("Restored {0}\n", t.FileName);
+                    }
+                    else
+                    {
+                        report.AppendFormat("ERROR writing {0}\n", t.FileName);
+                        overallSuccess = false;
+                    }
                 }
+            }
+
+            richTextBox1.AppendText(report.ToString());
+            if (overallSuccess)
+            {
+                label2.Text = "Success!";
+                label2.ForeColor = Color.Green;
             }
             else
             {
-                foreach (PatchBytes p in patches)
-                {
-                    System.Buffer.BlockCopy(p.Unpatched, 0, wowExe, p.Offset, p.Unpatched.Length);
-                }
-                try { File.Delete(FileName); File.Delete(BackupFile); }
-                catch { };
-
-                if (WriteByteArrayToFile(wowExe, FileName) == true)
-                {
-                    richTextBox1.AppendText("Successfully unpatched " + FileName + "!\n");
-                    label2.Text = "Success!";
-                    label2.ForeColor = Color.Green;
-                }
-                else
-                {
-                    label2.Text = "Error!";
-                    label2.ForeColor = Color.Red;
-                }
+                label2.Text = "Error!";
+                label2.ForeColor = Color.Red;
             }
-            richTextBox1.AppendText("Done.\n");
-            button1.Enabled = false;
+            richTextBox1.AppendText("Done.\n\n");
+            RefreshState();
         }
 
         public byte[] ReadByteArrayFromFile(string fileName)
@@ -165,7 +267,6 @@ namespace MaNGOSPatcher
         public bool WriteByteArrayToFile(byte[] buff, string fileName)
         {
             bool response = false;
-
             try
             {
                 FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite);
@@ -178,18 +279,10 @@ namespace MaNGOSPatcher
             {
                 Console.WriteLine(ex.Message);
             }
-
             return response;
         }
 
-        private void richTextBox1_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void pictureBox1_Click(object sender, EventArgs e)
-        {
-
-        }
+        private void richTextBox1_TextChanged(object sender, EventArgs e) { }
+        private void pictureBox1_Click(object sender, EventArgs e) { }
     }
 }

--- a/MaNGOSPatcher/Patcher/MaNGOSPatcher.csproj
+++ b/MaNGOSPatcher/Patcher/MaNGOSPatcher.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CrashReporter.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/MaNGOSPatcher/Patcher/Patches.cs
+++ b/MaNGOSPatcher/Patcher/Patches.cs
@@ -49,5 +49,28 @@ namespace MaNGOSatcher
                                        new byte[] { 0xEB }));
         }
     }
+
+    class Patch434Win64 : PatchInfo
+    {
+        protected override void Init()
+        {
+            ExeLength = 13592144;
+
+            // Patch #2a: Send function - NOP the je that skips type=0 path
+            Patches.Add(new PatchBytes(0xAAB6F,
+                                       new byte[] { 0x74, 0x08 },
+                                       new byte[] { 0x90, 0x90 }));
+
+            // Patch #2b: Send function - xor edx, edx to force type=0
+            Patches.Add(new PatchBytes(0xAAB71,
+                                       new byte[] { 0x41, 0x8B, 0xD5 },
+                                       new byte[] { 0x31, 0xD2, 0x90 }));
+
+            // Patch #3: NetClient - force connection[0] lookup
+            Patches.Add(new PatchBytes(0xA9AD3,
+                                       new byte[] { 0x74, 0x10 },
+                                       new byte[] { 0xEB, 0x10 }));
+        }
+    }
 }
 	

--- a/MaNGOSPatcher/Patcher/Program.cs
+++ b/MaNGOSPatcher/Patcher/Program.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace MaNGOSPatcher
@@ -13,9 +14,20 @@ namespace MaNGOSPatcher
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+            Application.ThreadException += new ThreadExceptionEventHandler(CrashReporter.OnThreadException);
+            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CrashReporter.OnUnhandledException);
+
+            try
+            {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(new Form1());
+            }
+            catch (Exception ex)
+            {
+                CrashReporter.ReportException("Application startup exception", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds `Wow-64.exe` patching support to MaNGOSPatcher for World of Warcraft Cataclysm 4.3.4 build 15595.

The existing 32-bit `Wow.exe` patching path is preserved. The patcher now supports patching both `Wow.exe` and `Wow-64.exe` when both are present, instead of only handling one executable.

## Background

The existing MaNGOSPatcher supports the 32-bit 4.3.4 client, but not the 64-bit client. The unpatched 64-bit client can reach login, but once in-world it suppresses important client-to-server packets. In practice this causes issues such as:

- NPC/unit names showing as `Unknown`
- NPC gossip/quest interaction not opening
- player movement not being seen correctly by the server
- missing in-world C2S packets in packet logs

The 64-bit patch bytes in this PR were derived from the known-working 32-bit patch behavior and verified locally against MaNGOS Three using packet logging and in-game testing.

## Changes

- Added `Patch434Win64` for `Wow-64.exe` build 15595.
- Added three final 64-bit patch sites:
  - `0xAAB6F`: `74 08` → `90 90`
  - `0xAAB71`: `41 8B D5` → `31 D2 90`
  - `0xA9AD3`: `74 10` → `EB 10`
- Updated patcher handling so multiple binaries can be detected and patched independently.
  - `Wow.exe`
  - `Wow-64.exe`
  - existing supported targets
- Preserved existing 32-bit `Patch434Win` patch bytes.
- Added full patch-site validation before writing patch bytes.
- Hardened backup/restore behavior so patching only proceeds after backup creation succeeds.
- Made unpatch safer.
- Added crash diagnostics/logging.
- Fixed a startup crash caused by incompatible icon resource deserialization.
- Added ignore rules to avoid accidentally committing `.exe` binaries/build outputs.

## Commit breakdown

Base before feature work:

- `81dde10` — existing MaNGOSPatcher state before the Wow-64 branch changes

Feature branch commits:

- `f70f8a4` — add Wow-64.exe support for Cata 4.3.4, including final 64-bit patch bytes, multi-binary detection, validation, and `.exe` ignore rule
- `020d0db` — harden backup/restore behavior so patching only writes after backup creation succeeds; make unpatch safer
- `7a67f90` — add crash diagnostics/logging and fix startup crash caused by incompatible icon resource deserialization

## Validation

Validated locally:

- Existing 32-bit `Wow.exe` patch bytes remain unchanged.
- `Wow-64.exe` build 15595 is detected by expected file size.
- All patch sites are validated before patching.
- If both `Wow.exe` and `Wow-64.exe` are present, both are handled independently.
- Backup creation is required before patch bytes are written.
- Build succeeds.
- Patched `Wow-64.exe` was tested locally against MaNGOS Three.

Runtime verification for the 64-bit client:

- Client enters world successfully.
- NPC/unit names resolve.
- NPC gossip/quest interaction works.
- Player movement works.
- Packet logs show restored in-world C2S traffic, including creature query, gossip hello, questgiver status query, and movement/heartbeat packets.

## Safety notes

This PR does not include or distribute any patched game binaries.

The patcher only applies byte patches to a user-provided local client executable when the expected file size and patch-site bytes match. If bytes do not match, patching is refused for that executable.

## Notes for reviewers

Please pay particular attention to:

- existing 32-bit `Wow.exe` behavior remains unchanged
- `Wow-64.exe` patch offsets and bytes match the listed values
- backup creation is required before patching
- multi-binary handling does not prevent users with only `Wow.exe` from using the patcher as before

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/tools/4)
<!-- Reviewable:end -->
